### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/intelligent_automation.yml
+++ b/.github/workflows/intelligent_automation.yml
@@ -1,4 +1,5 @@
 name: Smart Content Automation
+permissions: read-all
 
 on:
   schedule:
@@ -7,6 +8,8 @@ on:
 
 jobs:
   intelligent_automation:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     
     steps:
@@ -63,6 +66,7 @@ jobs:
           fi
 
   performance_monitoring:
+    permissions: {}
     runs-on: ubuntu-latest
     needs: intelligent_automation
     


### PR DESCRIPTION
Potential fix for [https://github.com/Zezooo342/Zezooo342.github.io/security/code-scanning/3](https://github.com/Zezooo342/Zezooo342.github.io/security/code-scanning/3)

To fix the problem, we should set explicit `permissions` in the workflow file at either the workflow root (to apply to all jobs by default) or per-job (for least privilege per job). In this workflow, we have two jobs:  
- `intelligent_automation`: needs `contents: write` as it pushes committed changes.
- `performance_monitoring`: does not interact with repo/API and can have `permissions: {} ` (no permissions) or `permissions: read-all` for full safety.

**Recommended fix:**  
- At the workflow root, set `permissions: read-all` as a safe default (disabling all write permissions).
- In the `intelligent_automation` job, explicitly override to `permissions: contents: write`.
- For `performance_monitoring` either:  
  - Omit a `permissions` block (inherits the read-all from the root),  
  - Or, for maximum safety, set `permissions: {}` in the job to grant it *no* token permissions.

Apply these changes at the appropriate locations in `.github/workflows/intelligent_automation.yml`, without altering job logic.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
