### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -1,4 +1,6 @@
 name: Daily Content
+permissions:
+  contents: read
 
 on:
   schedule:


### PR DESCRIPTION
Potential fix for [https://github.com/Zezooo342/Zezooo342.github.io/security/code-scanning/1](https://github.com/Zezooo342/Zezooo342.github.io/security/code-scanning/1)

To address the problem, add an explicit `permissions` block to the workflow. You can add it either at the root level (to apply to all jobs by default) or at the job level (to apply to the specific job). Since this workflow has only one job and currently does not require any write permissions (all jobs are just installing, checking out code, and running code), the minimal recommended permissions would be to set `contents: read` at the root of the workflow YAML file (just below the `name:` line, and above the `on:` block). This will ensure that the workflow and its jobs only have the permission to read repository contents via the `GITHUB_TOKEN`. If at some point additional permissions are required for this or another job, the block can be updated.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
